### PR TITLE
Add `index.d.ts` to `"files":` property in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "index.js",
-    "languages.json"
+    "languages.json",
+    "index.d.ts"
   ],
   "main": "index.js",
   "name": "language-iso-codes",


### PR DESCRIPTION
When installing via NPM, the .d.ts file isn't included.